### PR TITLE
modify methodology of traditional_chinese_mode

### DIFF
--- a/src/main/java/com/hankcs/lucene/TokenizerBuilder.java
+++ b/src/main/java/com/hankcs/lucene/TokenizerBuilder.java
@@ -55,9 +55,7 @@ public class TokenizerBuilder {
             return new Segment() {
                 @Override
                 protected List<Term> segSentence(char[] sentence) {
-                    List<Term> terms = segment.seg(HanLP.convertToSimplifiedChinese(new String(sentence)));
-                    terms.stream().forEach(t -> t.word = HanLP.convertToTraditionalChinese(t.word));
-                    return terms;
+                    return segment.seg(HanLP.convertToSimplifiedChinese(new String(sentence)));
                 }
             };
         }

--- a/src/main/java/com/hankcs/lucene/TokenizerBuilder.java
+++ b/src/main/java/com/hankcs/lucene/TokenizerBuilder.java
@@ -1,9 +1,9 @@
 package com.hankcs.lucene;
 
 import com.hankcs.cfg.Configuration;
+import com.hankcs.hanlp.HanLP;
 import com.hankcs.hanlp.seg.Segment;
 import com.hankcs.hanlp.seg.common.Term;
-import com.hankcs.hanlp.tokenizer.TraditionalChineseTokenizer;
 import org.apache.lucene.analysis.Tokenizer;
 
 import java.security.AccessController;
@@ -52,12 +52,12 @@ public class TokenizerBuilder {
             .enablePartOfSpeechTagging(configuration.isEnablePartOfSpeechTagging())
             .enableOffset(configuration.isEnableOffset());
         if (configuration.isEnableTraditionalChineseMode()) {
-            segment.enableIndexMode(false);
-            TraditionalChineseTokenizer.SEGMENT = segment;
             return new Segment() {
                 @Override
                 protected List<Term> segSentence(char[] sentence) {
-                    return TraditionalChineseTokenizer.segment(new String(sentence));
+                    List<Term> terms = segment.seg(HanLP.convertToSimplifiedChinese(new String(sentence)));
+                    terms.stream().forEach(t -> t.word = HanLP.convertToTraditionalChinese(t.word));
+                    return terms;
                 }
             };
         }


### PR DESCRIPTION
你好，

在繁體中文模式下，我想也需要 enableIndexMode。因為在 data 在 elasticsearch index 時需要細的精細度，當搜尋時才使用粗的精細度。例如：眼鏡框，在 elasticsearch index 時需要變成 "眼鏡框", "眼鏡", "鏡框"，這樣使用者不論打 "眼鏡框", "眼鏡", "鏡框"，都能搜尋到。

目前只有簡體 enableIndexMode 才能生效，我想這樣會限制到了繁體中文的使用上的靈活性。

謝謝